### PR TITLE
Bugfix: str_to_mb should return 0 when passed "0B"

### DIFF
--- a/seff-array.py
+++ b/seff-array.py
@@ -426,6 +426,9 @@ def mb_to_str(num):
 
 # convert mem str to number of megabytes
 def str_to_mb(s, cores=1):
+    if s == "0B":
+        return 0
+
     unit = s[-2:]
     num = float(s[:-2])
     if "c" in unit:


### PR DESCRIPTION
Compute Canada returns `sacct` lines like this:
```
21340270_1|simulate_gps.sh||00:01:33|1Gc|1|04:00:00|COMPLETED|01:03.077|wdconinc|wdconinc|beluga|0:0
21340270_1.batch|batch|415484K|00:01:33|1Gc|1||COMPLETED|01:03.077|||beluga|0:0
21340270_1.extern|extern|0|00:01:41|1Gc|1||COMPLETED|00:00:00|||beluga|0:0
```
with a `0` in the `MaxRSS` field on line 3. This fails to be parsed by `str_to_mb` (primarily since `float(s[:-2])` doesn't have two characters at the end to chop off and can't convert the empty string) This bugfix catches zeros explicitly.