### PR TITLE
Units

### DIFF
--- a/seff-array.py
+++ b/seff-array.py
@@ -589,7 +589,7 @@ def main(arrayID, m, t, c):
         "Memory Efficiency: %0.2f%% of %s"
         % (
             100 * rss_sum / (req_mem / req_cpus) / data_len,
-            (req_mem / req_cpus),
+            mb_to_str(req_mem / req_cpus),
         )
     )
 

--- a/seff-array.py
+++ b/seff-array.py
@@ -146,7 +146,7 @@ def histogram(
         buckets = len(boundaries)
     else:
         if req_mem:
-            req_mem_int = str_to_mb(req_mem, int(req_cpus))
+            req_mem_int = (req_mem / req_cpus)
 
         buckets = buckets or 10
         if buckets <= 0:


### PR DESCRIPTION
This fixes an issue with newer Slurm formatting of `sacct`'s memory reporting. We have added the new flag to fix the units to always report in `M` even when the job was set up requesting a different unit. 

